### PR TITLE
Validate downloaded filename

### DIFF
--- a/api/routes/download.go
+++ b/api/routes/download.go
@@ -28,6 +28,12 @@ func DownloadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// validate filename
+	if len(strings.Split(filename, "_wc_")) != 2 {
+		http.Error(w, "Invalid filename", http.StatusBadRequest)
+		return
+	}
+
 	// -> back to bytes
 	key, err := hex.DecodeString(keyHex)
 	if err != nil || len(key) != 32 {


### PR DESCRIPTION
In the old code there was a bug where go would throw a runtime error for "index out of range" if the filename provided did not contain the "\_wc\_" string. This caused the strings.Split(filename, "\_wc\_") to return a list containing only the filename, which causes an index out of range error at the part where the code tried to get the original filename back.

This PR forces the filename argument to have the right length, so that this bug doesn't happen again.

Another solution would be to add the filename to the encrypted file contents (the MIME type is already stored there), so that the file name doesn't even need to be in the link. (would be a cool feature to add regardless)

Edit: forgot that underscores are special in markdown